### PR TITLE
Add Madison HTCondor onboarding guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,27 @@
 
 Feel free to join the [GraphNeT Slack group](https://join.slack.com/t/graphnet-team/signup)!
 
+### Madison / HTCondor deployment
+
+This fork includes a validated Madison workflow for GraphNeT SQLite
+reconstruction with the tracked Energy, Track/Cascade, and Direction/Vertex
+models.
+
+**Start with the
+[Madison HTCondor Reconstruction Quickstart](docs/madison_condor_quickstart.md).**
+
+Supporting references:
+
+- [Architecture and validation record](docs/unified_workflow.md)
+- [Condor operational reference](workflows/reconstruction/condor/README.md)
+- [I3-to-SQLite conversion boundary](workflows/conversion/README.md)
+- [Model contracts and SHA256 checksums](models/MODELS.md)
+
+> Madison reconstruction uses a dedicated micromamba Python 3.8 / PyTorch 2.2
+> environment. Do not use the generic installation examples below, source the
+> IceCube CVMFS environment, or initialize micromamba in `.bashrc` for this
+> deployment.
+
 ### Publications using GraphNeT
 
 | Type | Title | DOI |

--- a/docs/madison_condor_quickstart.md
+++ b/docs/madison_condor_quickstart.md
@@ -1,0 +1,448 @@
+Exit code: 0
+Wall time: 0.5 seconds
+Output:
+# Madison HTCondor Reconstruction Quickstart
+
+This is the supported onboarding path for running the repository's Energy,
+Track/Cascade, and Direction/Vertex reconstruction workflows on the Madison
+HTCondor GPU pool.
+
+The guide starts from one or more GraphNeT SQLite databases. If the input is
+still IceCube I3 + GCD, read [Conversion from I3](#conversion-from-i3) before
+continuing.
+
+No Singularity image, container, IceTray setup, or shell activation is needed
+for SQLite reconstruction.
+
+## What the workflow produces
+
+For each input database, the three independent jobs produce:
+
+| Workflow | Model | Output suffix |
+| --- | --- | --- |
+| Energy | `models/energy/energy_model.pth` | `_E.csv` |
+| Track/Cascade | `models/track_cascade/track_cascade_model.pth` | `TC.csv` |
+| Direction/Vertex | `models/direction_vertex/direction_vertex_model.pth` | `_DV.csv` |
+
+The Energy model requires `IceCubeDeepCore` preprocessing. Track/Cascade and
+Direction/Vertex require `IceCube86`. These contracts are already encoded in
+the tracked Python entry points and must not be changed.
+
+## Storage layout
+
+Madison uses three different storage locations:
+
+| Location | Purpose |
+| --- | --- |
+| `/data/user/$USER/...` | Repository, micromamba, environment, input databases, models, final CSV files |
+| `/scratch/$USER/...` | Condor submit files and logs on `npx-submitter` |
+| `$_CONDOR_SCRATCH_DIR` | Execute-side sandbox created by HTCondor |
+
+Do not put Condor log paths under `/data/user`. Do not assume a GPU worker can
+see the submitter's `/scratch` directory. The tracked jobs transfer wrappers
+and stdout/stderr while writing final CSV files directly to shared
+`/data/user` storage.
+
+## Before starting
+
+You need:
+
+- a Madison account and access to `npx-submitter`;
+- writable `/data/user/$USER` and `/scratch/$USER` directories;
+- `git`, `curl`, and `tar` on the submit host;
+- one or more GraphNeT SQLite `.db` files directly inside one input directory;
+- the pulse table name used during conversion, commonly
+  `SplitRTCleanedInIcePulses` or `SRTInIcePulses`.
+
+Start in a clean Bash shell. Do **not** source the IceCube CVMFS setup for
+reconstruction.
+
+## 1. Clone `main` to shared storage
+
+```bash
+export REPO="/data/user/$USER/software/graphnet"
+
+git clone --branch main --single-branch \
+  https://github.com/JiyuanLiao2000/graphnet.git "$REPO"
+
+cd "$REPO"
+git status -sb
+```
+
+For an existing checkout:
+
+```bash
+cd "$REPO"
+git switch main
+git pull --ff-only
+```
+
+The repository must be under shared storage such as `/data/user`; GPU workers
+cannot use a checkout located only under submitter-local `/scratch`.
+
+## 2. Install micromamba without modifying `.bashrc`
+
+The validated deployment used micromamba 2.9.0. Micromamba is a standalone
+binary and is not committed to this repository. The command below downloads
+the current official Linux x86-64 build. For an exact reproduction, obtain the
+2.9.0 build from the official micromamba releases instead.
+
+```bash
+export MAMBA_DIR="/data/user/$USER/software/micromamba"
+export MAMBA="$MAMBA_DIR/bin/micromamba"
+
+if [ ! -x "$MAMBA" ]; then
+  mkdir -p "$MAMBA_DIR"
+  cd "$MAMBA_DIR"
+  curl -Ls https://micro.mamba.pm/api/micromamba/linux-64/latest \
+    | tar -xvj bin/micromamba
+fi
+
+"$MAMBA" --version
+```
+
+Official installation documentation:
+<https://mamba.readthedocs.io/en/stable/installation/micromamba-installation.html>
+
+Do not run `micromamba shell init`. The workflow uses explicit paths and
+`micromamba run`, so no shell activation or `.bashrc` change is required.
+
+## 3. Create the reconstruction environment
+
+```bash
+export MAMBA_ROOT_PREFIX="/data/user/$USER/envs/micromamba"
+export ENV_NAME="graphnet-reco"
+export ENV_PREFIX="$MAMBA_ROOT_PREFIX/envs/$ENV_NAME"
+
+cd "$REPO"
+MAMBA="$MAMBA" \
+MAMBA_ROOT_PREFIX="$MAMBA_ROOT_PREFIX" \
+ENV_NAME="$ENV_NAME" \
+ENV_PREFIX="$ENV_PREFIX" \
+bash environments/setup_reconstruction_madison.sh
+```
+
+The script creates the tested Python 3.8 / PyTorch 2.2 + CUDA 11.8 environment,
+installs the matching PyG wheels, verifies `CXXABI_1.3.15`, and checks the
+legacy-compatible Polars installation.
+
+The final output should include values equivalent to:
+
+```text
+python: 3.8.19
+torch: 2.2.0+cu118
+cuda built: 11.8
+dill: 0.3.8
+polars-lts-cpu: 0.20.21
+torch_geometric: 2.5.2
+```
+
+Do not replace `polars-lts-cpu` with standard `polars`. Some Madison GPU
+workers are legacy `x86_64-v2` systems, and the standard wheel can terminate
+with `SIGILL` / exit code 132.
+
+## 4. Verify the models
+
+```bash
+cd "$REPO"
+sha256sum \
+  models/energy/energy_model.pth \
+  models/track_cascade/track_cascade_model.pth \
+  models/direction_vertex/direction_vertex_model.pth
+```
+
+Expected SHA256 values:
+
+```text
+c64b0d882cd0e025780e1b414831b1e94de06185560cbf9d693e16798a118b6a
+1322fd213801f680b61045c72557440239356f2e21329879011d210d666193ad
+88db3f74d0399ddf13a303b9b74dbe5ca3c68f101ed5cf607c5f037ad1f8f54c
+```
+
+A recommended preflight loads all three serialized models before requesting a
+GPU slot:
+
+```bash
+unset PYTHONHOME
+unset PYTHONPATH
+export PATH="/usr/bin:/bin:${PATH:-}"
+export LD_LIBRARY_PATH="$ENV_PREFIX/lib:${LD_LIBRARY_PATH:-}"
+export PYTHONPATH="$REPO/src"
+
+"$MAMBA" run -p "$ENV_PREFIX" python - \
+  "$REPO/models/energy/energy_model.pth" \
+  "$REPO/models/track_cascade/track_cascade_model.pth" \
+  "$REPO/models/direction_vertex/direction_vertex_model.pth" <<'PY'
+import sys
+from graphnet.models import Model
+
+for model_path in sys.argv[1:]:
+    model = Model.load(model_path)
+    print(f"PASS: {model_path} -> {type(model).__name__}")
+PY
+```
+
+This also verifies that the repository's custom Direction/Vertex classes are
+available at the import paths required by the pickle.
+
+See `models/MODELS.md` for the mapping between files, workflows, and detector
+preprocessing.
+
+## 5. Check the SQLite input
+
+Set the input directory and pulse table:
+
+```bash
+export INPUT_DIR="/data/user/$USER/path/to/sqlite"
+export PULSEMAP="SplitRTCleanedInIcePulses"
+
+find "$INPUT_DIR" -maxdepth 1 -type f -name '*.db' -print
+```
+
+The reconstruction scripts discover only `.db` files directly inside
+`INPUT_DIR`; discovery is not recursive.
+
+This optional check confirms that every database has the required `truth` and
+pulse tables:
+
+```bash
+python3 - "$INPUT_DIR" "$PULSEMAP" <<'PY'
+import glob
+import os
+import sqlite3
+import sys
+
+input_dir, pulsemap = sys.argv[1:]
+databases = sorted(glob.glob(os.path.join(input_dir, "*.db")))
+if not databases:
+    raise SystemExit(f"No .db files found in {input_dir}")
+
+for database in databases:
+    with sqlite3.connect(database) as connection:
+        tables = {
+            row[0]
+            for row in connection.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            )
+        }
+    missing = {"truth", pulsemap} - tables
+    if missing:
+        raise SystemExit(f"{database}: missing tables {sorted(missing)}")
+    print(f"PASS: {database}")
+PY
+```
+
+Use exactly the pulse table present in the databases. A pulsemap mismatch is
+not repaired by the reconstruction job.
+
+## 6. Prepare a submit directory
+
+```bash
+export SUBMIT_DIR="/scratch/$USER/graphnet-reconstruction"
+export OUTPUT_BASE="/data/user/$USER/graphnet-reconstruction-output"
+
+mkdir -p "$SUBMIT_DIR" "$OUTPUT_BASE"
+cp "$REPO"/workflows/reconstruction/condor/{energy,track_cascade,direction_vertex}.{sh,sub} \
+  "$SUBMIT_DIR"/
+cd "$SUBMIT_DIR"
+```
+
+The `.sub` files contain the original validated smoke-test paths as examples.
+Never submit them unchanged. The commands below override every user-specific
+path without editing the tracked templates.
+
+## 7. Choose smoke-test settings
+
+Start with one database before processing a full directory:
+
+```bash
+export NUM_WORKERS=4
+export BATCH_SIZE=10
+export MAX_FILES=1
+```
+
+`NUM_WORKERS` must be a positive integer. The submit files enforce:
+
+```text
+request_cpus = num_workers
+```
+
+The four-worker / four-CPU / 12 GB profile passed Energy, Track/Cascade, and
+Direction/Vertex validation. If a workload needs different resources, change
+the worker count and memory together and test on one database first.
+
+## 8. Submit Energy
+
+```bash
+condor_submit energy.sub \
+  -batch-name graphnet-energy \
+  -append "input_dir = $INPUT_DIR" \
+  -append "output_dir = $OUTPUT_BASE/energy" \
+  -append "model_path = $REPO/models/energy/energy_model.pth" \
+  -append "pulsemap = $PULSEMAP" \
+  -append "graphnet_root = $REPO" \
+  -append "env_prefix = $ENV_PREFIX" \
+  -append "mamba = $MAMBA" \
+  -append "num_workers = $NUM_WORKERS" \
+  -append "batch_size = $BATCH_SIZE" \
+  -append "max_files = $MAX_FILES" \
+  -append "request_memory = 12GB"
+```
+
+## 9. Submit Track/Cascade
+
+```bash
+condor_submit track_cascade.sub \
+  -batch-name graphnet-track-cascade \
+  -append "input_dir = $INPUT_DIR" \
+  -append "output_dir = $OUTPUT_BASE/track_cascade" \
+  -append "model_path = $REPO/models/track_cascade/track_cascade_model.pth" \
+  -append "pulsemap = $PULSEMAP" \
+  -append "graphnet_root = $REPO" \
+  -append "env_prefix = $ENV_PREFIX" \
+  -append "mamba = $MAMBA" \
+  -append "num_workers = $NUM_WORKERS" \
+  -append "batch_size = $BATCH_SIZE" \
+  -append "max_files = $MAX_FILES" \
+  -append "request_memory = 12GB"
+```
+
+## 10. Submit Direction/Vertex
+
+```bash
+condor_submit direction_vertex.sub \
+  -batch-name graphnet-direction-vertex \
+  -append "input_dir = $INPUT_DIR" \
+  -append "output_dir = $OUTPUT_BASE/direction_vertex" \
+  -append "model_path = $REPO/models/direction_vertex/direction_vertex_model.pth" \
+  -append "pulsemap = $PULSEMAP" \
+  -append "graphnet_root = $REPO" \
+  -append "env_prefix = $ENV_PREFIX" \
+  -append "mamba = $MAMBA" \
+  -append "num_workers = $NUM_WORKERS" \
+  -append "batch_size = $BATCH_SIZE" \
+  -append "max_files = $MAX_FILES" \
+  -append "request_memory = 12GB"
+```
+
+The three jobs are independent and may run concurrently.
+
+The tracked GPU request is:
+
+```text
+request_gpus = 1
+gpus_minimum_capability = 6.1
+gpus_minimum_memory = 6GB
+```
+
+This excludes GTX 980 GPUs while allowing the validated GTX 1080 and A40
+classes.
+
+## 11. Monitor the jobs
+
+```bash
+condor_q
+```
+
+For an idle job that is not matching:
+
+```bash
+condor_q -better-analyze <cluster.proc>
+```
+
+After completion, inspect all three log types:
+
+```bash
+ls -lh *.log *.out *.err
+```
+
+- `.log` records scheduling, execution host, transfer, and exit status.
+- `.out` records the wrapper configuration and GraphNeT progress.
+- `.err` contains Python warnings and tracebacks.
+
+A successful Condor event log ends with normal termination and return value 0.
+Warnings about `icecube` being unavailable are expected for reconstruction
+from SQLite and are not failures.
+
+## 12. Verify the CSV outputs
+
+```bash
+find "$OUTPUT_BASE" -maxdepth 2 -type f -name '*.csv' -print
+```
+
+Inspect headers and a few rows before scaling up:
+
+```bash
+head -n 3 "$OUTPUT_BASE"/energy/*.csv
+head -n 3 "$OUTPUT_BASE"/track_cascade/*.csv
+head -n 3 "$OUTPUT_BASE"/direction_vertex/*.csv
+```
+
+The Track/Cascade prediction column is currently named `target_pred`. This is
+a known non-blocking naming issue; the validated prediction values are not
+affected.
+
+## 13. Process every database
+
+After the one-file smoke test passes, choose fresh output directories and set:
+
+```bash
+export MAX_FILES=-1
+```
+
+Repeat the three submit commands. `-1` tells each workflow to process every
+`.db` file discovered directly inside `INPUT_DIR`.
+
+Do not run multiple jobs that write the same database/workflow result into the
+same output directory. For a large campaign, split databases into separate
+input directories or build a manifest-driven layer around these one-directory
+entry points.
+
+## Common failures
+
+| Symptom | Cause | Action |
+| --- | --- | --- |
+| `No module named encodings` | IceCube CVMFS set `PYTHONHOME`/`PYTHONPATH` | Start a clean shell and use the tracked reconstruction wrapper; do not source CVMFS |
+| `CXXABI_1.3.15 not found` | Worker loaded `/lib64/libstdc++.so.6` | Use the tracked wrapper and the environment created by the setup script |
+| `Failed to find a shell to run the script with` | Minimal worker `PATH` | Use the tracked wrapper, which adds `/usr/bin:/bin` before micromamba |
+| `prefetch_factor option could only be specified in multiprocessing` | `num_workers=0` | Set a positive worker count; keep `request_cpus = num_workers` |
+| Exit code 132 / `Illegal instruction` during `import polars` | Standard Polars wheel on a legacy CPU | Recreate the environment from `main` and verify `polars-lts-cpu==0.20.21` |
+| Logs cannot be written under `/data/user` | Madison Condor log policy | Submit from `/scratch/$USER` and keep final data under `/data/user/$USER` |
+| Job remains idle | No currently available slot satisfies CPU, memory, GPU, and machine `START` policies | Use `condor_q <job> -better-analyze`; avoid pinning one host |
+| No CSV and nonzero exit code | Reconstruction failed before output | Read `.err`, `.out`, and the final termination entry in `.log` |
+
+Lightning may recommend more workers than the job requested. Do not follow that
+generic warning beyond the Condor CPU allocation. Request the intended CPU
+count and set `num_workers` to the same value.
+
+Do not work around the Polars failure with `POLARS_SKIP_CPU_CHECK`; skipping a
+check cannot add missing CPU instructions.
+
+## Conversion from I3
+
+SQLite reconstruction and I3 conversion intentionally use different Python
+environments. The active conversion workflow is under `workflows/conversion/`,
+but its IceTray `env-shell`, private Python, and Python site-packages paths are
+Madison deployment-specific.
+
+If starting from I3 + GCD, read `workflows/conversion/README.md`. Do not run
+IceCube CVMFS setup inside a reconstruction job, and do not try to load the
+serialized reconstruction models in the Python 3.12 conversion environment.
+
+## Key files
+
+| Purpose | File |
+| --- | --- |
+| Environment installer | `environments/setup_reconstruction_madison.sh` |
+| Pinned dependency mirror | `environments/reconstruction-madison.yml` |
+| Condor operational reference | `workflows/reconstruction/condor/README.md` |
+| Energy entry point | `workflows/reconstruction/energy.py` |
+| Track/Cascade entry point | `workflows/reconstruction/track_cascade.py` |
+| Direction/Vertex entry point | `workflows/reconstruction/direction_vertex.py` |
+| Model contracts and checksums | `models/MODELS.md` |
+| Architecture and validation record | `docs/unified_workflow.md` |
+
+Reference scripts under `workflows/**/reference/` are preserved historical
+inputs. They are not the active deployment entry points and should not be
+edited for normal production use.
+

--- a/docs/madison_condor_quickstart.md
+++ b/docs/madison_condor_quickstart.md
@@ -1,6 +1,3 @@
-Exit code: 0
-Wall time: 0.5 seconds
-Output:
 # Madison HTCondor Reconstruction Quickstart
 
 This is the supported onboarding path for running the repository's Energy,

--- a/docs/unified_workflow.md
+++ b/docs/unified_workflow.md
@@ -24,6 +24,10 @@ SQLite database
 PACE is the reconstruction regression environment. Madison/HTCondor is the
 deployment target for the complete workflow.
 
+New users should start with `docs/madison_condor_quickstart.md`. It provides the
+supported clone, environment creation, input validation, submission,
+monitoring, output verification, and troubleshooting path.
+
 ## GraphNeT baseline
 
 The unified repository is based on GraphNeT commit
@@ -379,6 +383,7 @@ Git-managed reconstruction environment was recreated independently, all three
 serialized models loaded successfully, and Energy inference passed on a legacy
 CPU worker with the compatibility Polars build.
 
-The Madison deployment and reproducibility gates are complete. A final review
-of the integration branch remains before any merge to `main`; this environment
-update does not merge the branch.
+The Madison deployment and reproducibility gates are complete. The verified
+integration was merged into `main` with its linear commit history preserved.
+Operational onboarding is maintained in
+`docs/madison_condor_quickstart.md`.

--- a/environments/setup_reconstruction_madison.sh
+++ b/environments/setup_reconstruction_madison.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# User guide: docs/madison_condor_quickstart.md
+
 # Reproduce the Madison/HTCondor reconstruction environment used by the
 # validated Energy, Track/Cascade, and Direction/Vertex models.
 #
@@ -13,8 +15,8 @@ set -euo pipefail
 unset PYTHONHOME
 unset PYTHONPATH
 
-MAMBA="${MAMBA:-/data/user/jliao/software/micromamba/bin/micromamba}"
-MAMBA_ROOT_PREFIX="${MAMBA_ROOT_PREFIX:-/data/user/jliao/envs/micromamba}"
+MAMBA="${MAMBA:-/data/user/${USER}/software/micromamba/bin/micromamba}"
+MAMBA_ROOT_PREFIX="${MAMBA_ROOT_PREFIX:-/data/user/${USER}/envs/micromamba}"
 ENV_NAME="${ENV_NAME:-graphnet-reco}"
 ENV_PREFIX="${ENV_PREFIX:-${MAMBA_ROOT_PREFIX}/envs/${ENV_NAME}}"
 

--- a/workflows/conversion/README.md
+++ b/workflows/conversion/README.md
@@ -1,6 +1,3 @@
-Exit code: 0
-Wall time: 0.5 seconds
-Output:
 # Madison HTCondor I3-to-SQLite conversion
 
 This directory contains the active Madison conversion workflow:

--- a/workflows/conversion/README.md
+++ b/workflows/conversion/README.md
@@ -1,0 +1,113 @@
+Exit code: 0
+Wall time: 0.5 seconds
+Output:
+# Madison HTCondor I3-to-SQLite conversion
+
+This directory contains the active Madison conversion workflow:
+
+- `conversion.py`
+- `exe.sh`
+- `condor.sub`
+
+Each Condor process converts one I3 file plus its matching GCD into one
+GraphNeT SQLite database. The pulse table name is a parameter.
+
+## Important portability boundary
+
+The current conversion workflow is validated on Madison, but it is not a
+generic installation recipe. It intentionally depends on a site-specific
+IceCube Python 3.12 stack:
+
+- IceCube CVMFS `py3-v4.4.2` setup;
+- an IceTray `env-shell` path;
+- a private Python executable;
+- a private Python `site-packages` path used by `conversion.py`.
+
+Those private paths are not committed as software artifacts and may not be
+readable by another user. A new user must obtain or build an equivalent
+IceTray/GraphNeT conversion environment and update the active workflow paths
+before submitting. The micromamba Python 3.8 reconstruction environment is not
+a replacement for this conversion environment.
+
+If SQLite databases already exist, skip this directory and follow
+`docs/madison_condor_quickstart.md`.
+
+## Inputs
+
+The conversion CLI is:
+
+```text
+conversion.py <gcd_file_path> <i3_file_path> <output_directory> <pulse_key>
+```
+
+GCD/I3 matching is deliberately outside the converter. Generate a two-column,
+whitespace-separated manifest with one job per row:
+
+```text
+/shared/path/GCD_Run001.i3.gz /shared/path/Run001.i3.zst
+/shared/path/GCD_Run002.i3.gz /shared/path/Run002.i3.zst
+```
+
+GCD tar archives are supported by `exe.sh`; it extracts the first matching
+`*.i3*` file into a job-local temporary directory.
+
+Common pulse keys include:
+
+- `SplitRTCleanedInIcePulses`
+- `SRTInIcePulses`
+
+Use the pulse key actually present in the source I3 files. Reconstruction must
+later use the same table name.
+
+## Paths that must be reviewed
+
+Before submission, review all of the following:
+
+### `condor.sub`
+
+- `pulse_key`
+- `graphnet_root`
+- shared SQLite output directory in `arguments`
+- `/scratch/$USER/...` log, stdout, and stderr paths
+- manifest filename in the `queue ... from ...` line
+
+### `exe.sh`
+
+- IceCube CVMFS setup version
+- IceTray `env-shell.sh` path
+- private Python executable path
+
+### `conversion.py`
+
+- private Python `site-packages` path (`my_env_path`)
+
+Do not submit the tracked file unchanged under another account: its default
+paths are the validated author's smoke/deployment paths.
+
+## Storage and Condor behavior
+
+- Submit and log files belong under submitter-local `/scratch/$USER/...`.
+- The repository, input I3/GCD, and final SQLite databases must be on storage
+  visible to execute workers, such as `/data/user/...` or experiment storage.
+- `should_transfer_files = YES` transfers `conversion.py` and captures job
+  output correctly.
+- Conversion failures propagate through `exe.sh` as a nonzero Condor exit
+  code.
+
+One successful job produces one `.db` named from the I3 basename. No database
+merge step is performed by this workflow.
+
+## Environment separation
+
+Do not source or reuse the conversion CVMFS environment for reconstruction.
+IceCube setup exports `PYTHONHOME` and `PYTHONPATH`, which can break the
+micromamba reconstruction Python. The reconstruction wrappers clear these
+variables and use the separate environment documented in
+`docs/madison_condor_quickstart.md`.
+
+## Active and reference files
+
+Use the files directly under `workflows/conversion/` for deployment. Files
+under `workflows/conversion/reference/condor/` preserve the original reference
+workflow and should not be modified.
+

--- a/workflows/conversion/condor.sub
+++ b/workflows/conversion/condor.sub
@@ -1,3 +1,7 @@
+# USER SETUP REQUIRED
+# This validated Madison example contains user- and site-specific paths.
+# Review workflows/conversion/README.md before submitting under another account.
+
 # HTCondor submission settings.
 executable = exe.sh
 

--- a/workflows/reconstruction/condor/README.md
+++ b/workflows/reconstruction/condor/README.md
@@ -1,43 +1,78 @@
+Exit code: 0
+Wall time: 0.5 seconds
+Output:
 # Madison HTCondor reconstruction
 
-These files run GraphNeT reconstruction from SQLite databases on Madison GPU
-workers. Conversion uses a separate IceTray/Python 3.12 environment; do not
-source the IceCube CVMFS setup in reconstruction jobs.
+These files run Energy, Track/Cascade, and Direction/Vertex reconstruction
+from GraphNeT SQLite databases on Madison GPU workers.
+
+**New users should start with the complete
+[`docs/madison_condor_quickstart.md`](../../../docs/madison_condor_quickstart.md).**
+This README is the shorter operational reference for the files in this
+directory.
+
+Conversion uses a separate IceTray/Python 3.12 environment. Do not source the
+IceCube CVMFS setup in reconstruction jobs.
 
 ## Files
 
-- `energy.sh` and `energy.sub`
-- `track_cascade.sh` and `track_cascade.sub`
-- `direction_vertex.sh` and `direction_vertex.sub`
+| Workflow | Wrapper | Submit file | Default memory |
+| --- | --- | --- | --- |
+| Energy | `energy.sh` | `energy.sub` | 8 GB |
+| Track/Cascade | `track_cascade.sh` | `track_cascade.sub` | 12 GB |
+| Direction/Vertex | `direction_vertex.sh` | `direction_vertex.sub` | 12 GB |
 
-The wrappers share the validated environment-isolation, C++ runtime, shell
-`PATH`, GPU, file-transfer, and shared-storage contract.
+The wrapper is transferred into the execute sandbox. Python entry points,
+models, the micromamba environment, input databases, and output directories
+remain on worker-visible shared storage.
+
+## Do not submit the templates unchanged
+
+The tracked `.sub` files preserve the original validated smoke-test paths under
+`/data/user/jliao/...`. Every user must override or edit these macros:
+
+| Macro | Meaning |
+| --- | --- |
+| `input_dir` | Shared directory containing direct `*.db` children |
+| `output_dir` | Shared, writable directory for final CSV files |
+| `model_path` | Workflow-specific tracked `.pth` file |
+| `pulsemap` | Pulse table that exists in every input database |
+| `graphnet_root` | Shared checkout of this repository |
+| `env_prefix` | Created micromamba environment prefix |
+| `mamba` | Executable micromamba binary |
+| `num_workers` | Positive DataLoader worker count |
+| `batch_size` | Positive inference batch size |
+| `max_files` | `1` for a smoke test or `-1` for all discovered databases |
+
+Prefer `condor_submit -append` so the Git-tracked templates remain unchanged.
+For example:
+
+```bash
+condor_submit energy.sub \
+  -append "input_dir = $INPUT_DIR" \
+  -append "output_dir = $OUTPUT_DIR" \
+  -append "model_path = $REPO/models/energy/energy_model.pth" \
+  -append "pulsemap = $PULSEMAP" \
+  -append "graphnet_root = $REPO" \
+  -append "env_prefix = $ENV_PREFIX" \
+  -append "mamba = $MAMBA" \
+  -append "num_workers = 4" \
+  -append "batch_size = 10" \
+  -append "max_files = 1" \
+  -append "request_memory = 12GB"
+```
+
+The Quickstart provides complete commands for all three workflows.
 
 ## Storage contract
 
-- Submit files and Condor logs: submitter-local `/scratch/<user>/...`
+- Submit files and Condor logs: submitter-local `/scratch/$USER/...`
 - Runtime sandbox: `$_CONDOR_SCRATCH_DIR`
-- Repository, micromamba environment, input databases, models, and final CSV:
-  worker-visible shared `/data/user/<user>/...`
+- Repository, environment, databases, models, and final CSV:
+  worker-visible shared `/data/user/$USER/...`
 
 Madison prohibits writing Condor logs directly under `/data/user`. Workers
 must not be expected to see the submitter's `/scratch` path.
-
-## Prepare a submission
-
-Pull the desired Git revision, copy the relevant `.sh` and `.sub` pair to a
-directory under `/scratch`, and submit from that directory. Edit the path
-macros near the top of each submit file for the target checkout, environment,
-model, input directory, and shared output directory.
-
-The tracked files are one-database smoke configurations:
-
-```text
-batch_size = 10
-max_files = 1
-```
-
-Set `max_files = -1` to process all databases found in `input_dir`.
 
 ## Resources
 
@@ -48,49 +83,17 @@ gpus_minimum_capability = 6.1
 gpus_minimum_memory = 6GB
 ```
 
-The required accounting rule is:
+This excludes GTX 980 GPUs while allowing validated GTX 1080 and A40 workers.
+
+The CPU accounting rule is:
 
 ```text
 request_cpus = num_workers
 ```
 
 `num_workers` must be at least one because this GraphNeT DataLoader configures
-`prefetch_factor`. Energy was initially validated with one worker. Track/Cascade
-and Direction/Vertex were validated concurrently with four workers, four
-requested CPUs, and 12 GB of requested memory per job. The clean-environment
-Energy compatibility test subsequently passed on a legacy CPU worker with the
-same four-worker, four-CPU, 12 GB profile.
-
-## Legacy CPU compatibility
-
-Some Madison GPU workers advertise `Microarch = "x86_64-v2"` and do not
-advertise `has_avx2`. The standard Polars 0.20.21 wheel can raise
-`SIGILL` (exit code 132) while importing on these workers because it expects
-AVX2, FMA, BMI1, BMI2, and LZCNT instructions. The Madison
-reconstruction environment therefore uses `polars-lts-cpu==0.20.21`,
-which still imports as `polars`.
-
-Do not use `POLARS_SKIP_CPU_CHECK` as a workaround: bypassing a check
-cannot add missing CPU instructions. Production jobs should remain portable
-across the heterogeneous pool and should not require AVX2.
-
-To list legacy-CPU GPU workers:
-
-```bash
-condor_status \
-  -constraint 'TotalGPUs > 0 && (has_avx2 =!= true)' \
-  -af Machine Microarch TotalGPUs | sort -u
-```
-
-To deliberately validate the compatibility build, add the temporary constraint
-at submission time:
-
-```bash
-condor_submit energy.sub \
-  -append 'requirements = (TARGET.has_avx2 =!= true)'
-```
-
-Do not add that constraint to the tracked production submit files.
+`prefetch_factor`. The four-worker / four-CPU / 12 GB profile passed all three
+workflows. Test resource changes on one database before scaling up.
 
 ## Runtime isolation
 
@@ -101,11 +104,57 @@ Each wrapper performs these steps before Python starts:
 3. Prepends `${ENV_PREFIX}/lib` to `LD_LIBRARY_PATH` so the environment
    `libstdc++` provides `CXXABI_1.3.15`.
 4. Sets `PYTHONPATH` to the checked-out repository's `src` directory.
-5. Runs micromamba by the explicit environment prefix without shell activation
-   or `.bashrc` changes.
+5. Runs micromamba by explicit prefix without activation or `.bashrc` changes.
+
+Use the tracked wrappers. Reimplementing these exports in an ad-hoc submit
+script commonly reintroduces the Python contamination or C++ ABI failures that
+the deployment layer is designed to prevent.
+
+## Legacy CPU compatibility
+
+Some Madison GPU workers are `x86_64-v2` systems without AVX2. The standard
+Polars 0.20.21 wheel can terminate with `SIGILL` / exit code 132 on these
+workers. The environment therefore pins `polars-lts-cpu==0.20.21`, which still
+imports as `polars`.
+
+Do not use `POLARS_SKIP_CPU_CHECK`, and do not add an AVX2 requirement to normal
+production jobs. The compatibility package is intended to keep the workflow
+portable across the heterogeneous pool.
+
+To deliberately test a legacy CPU only, add this option to the complete
+Quickstart submission command:
+
+```text
+-append 'requirements = (TARGET.has_avx2 =!= true)'
+```
+
+That constraint is diagnostic and must not be copied into production submit
+files.
 
 ## Validated outputs
 
 Using pulsemap `SplitRTCleanedInIcePulses`, the Madison smoke database produced
-Energy, Track/Cascade, and Direction/Vertex CSV files successfully. The scripts
-use the suffixes `_E.csv`, `TC.csv`, and `_DV.csv`, respectively.
+all three CSV outputs successfully:
+
+- Energy: `_E.csv`
+- Track/Cascade: `TC.csv`
+- Direction/Vertex: `_DV.csv`
+
+The Track/Cascade prediction column is currently called `target_pred`. The
+name is a known non-blocking issue; prediction values were validated.
+
+## Troubleshooting
+
+The Quickstart contains the full symptom/cause/action table. The first checks
+for any failed job are:
+
+```bash
+condor_q
+condor_q -better-analyze <cluster.proc>
+ls -lh *.log *.out *.err
+```
+
+Do not treat warnings about `icecube` being unavailable as reconstruction
+failures when the input is SQLite. Always use the Condor event log's final exit
+code and the existence/content of the expected CSV as the success criteria.
+

--- a/workflows/reconstruction/condor/README.md
+++ b/workflows/reconstruction/condor/README.md
@@ -1,6 +1,3 @@
-Exit code: 0
-Wall time: 0.5 seconds
-Output:
 # Madison HTCondor reconstruction
 
 These files run Energy, Track/Cascade, and Direction/Vertex reconstruction

--- a/workflows/reconstruction/condor/direction_vertex.sub
+++ b/workflows/reconstruction/condor/direction_vertex.sub
@@ -1,3 +1,8 @@
+# USER SETUP REQUIRED
+# The path macros below are validated smoke-test examples owned by the original
+# deployer. Do not submit this file unchanged. Follow
+# docs/madison_condor_quickstart.md and override every user-specific path.
+
 universe = vanilla
 
 executable = direction_vertex.sh

--- a/workflows/reconstruction/condor/energy.sub
+++ b/workflows/reconstruction/condor/energy.sub
@@ -1,3 +1,8 @@
+# USER SETUP REQUIRED
+# The path macros below are validated smoke-test examples owned by the original
+# deployer. Do not submit this file unchanged. Follow
+# docs/madison_condor_quickstart.md and override every user-specific path.
+
 universe = vanilla
 
 executable = energy.sh

--- a/workflows/reconstruction/condor/track_cascade.sub
+++ b/workflows/reconstruction/condor/track_cascade.sub
@@ -1,3 +1,8 @@
+# USER SETUP REQUIRED
+# The path macros below are validated smoke-test examples owned by the original
+# deployer. Do not submit this file unchanged. Follow
+# docs/madison_condor_quickstart.md and override every user-specific path.
+
 universe = vanilla
 
 executable = track_cascade.sh


### PR DESCRIPTION
## Summary

- add a prominent Madison / HTCondor entry point to the root README
- add a complete self-service quickstart covering clone, micromamba installation, environment creation, model and SQLite preflight checks, Energy/Track-Cascade/Direction-Vertex submission, output validation, scaling, and troubleshooting
- document the site-specific boundary of the IceTray conversion workflow
- make reconstruction environment defaults user-relative instead of account-specific
- add safety warnings to tracked submit templates so new users do not submit the original smoke-test paths unchanged
- rewrite the reconstruction Condor README as an operational reference

## Why

The validated Madison workflow was present in `main`, but a new Condor user still had to reconstruct the deployment procedure from several files and could accidentally submit paths owned by the original deployer. This change makes the supported path discoverable and records the runtime requirements that were learned during real batch validation.

## User impact

A Madison user starting with GraphNeT SQLite databases can now follow one guide from a clean checkout through all three reconstruction products. The guide explicitly covers the two-environment architecture, `num_workers >= 1`, one-to-one CPU/worker accounting, C++ ABI isolation, legacy non-AVX2 workers, GPU constraints, shared/output storage, and Condor file transfer behavior.

The conversion README clearly states which private IceTray/Python paths are deployment-specific and must be supplied by a site maintainer.

## Validation

- branch contains only the onboarding changes and is zero commits behind `main`
- remote contents of all 10 changed files were re-read and matched the intended contents byte-for-byte
- removed accidental temporary command-output headers found during technical review
- all Markdown code fences are balanced
- all three full submit examples override every user-specific path and runtime macro
- reconstruction and conversion submit-file executable bodies are unchanged; only safety comments were added
- no reference scripts, model files, reconstruction Python logic, binaries, environments, or shared libraries were changed
