### PR TITLE
Complete Madison HTCondor end-to-end workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ Supporting references:
 > user-owned micromamba Python 3.8 / PyTorch 2.2 environment. Follow the
 > Quickstart instead of the generic installation examples below, and do not
 > initialize micromamba in `.bashrc`.
+>
+> **Madison users must not run `pip install .`, `pip install -e .`, or the
+> generic `requirements/torch_*.txt` installation commands in either validated
+> runtime.** The repository's `setup.py` and the generic Install section below
+> are retained for non-Madison GraphNeT development; they do not encode the
+> tested two-runtime Condor dependency contract.
 
 ### Publications using GraphNeT
 

--- a/README.md
+++ b/README.md
@@ -20,24 +20,30 @@ Feel free to join the [GraphNeT Slack group](https://join.slack.com/t/graphnet-t
 
 ### Madison / HTCondor deployment
 
-This fork includes a validated Madison workflow for GraphNeT SQLite
-reconstruction with the tracked Energy, Track/Cascade, and Direction/Vertex
-models.
+This fork includes a validated end-to-end Madison workflow:
+
+```text
+IceCube I3 + GCD -> GraphNeT SQLite -> Energy / Track-Cascade / Direction-Vertex
+```
 
 **Start with the
-[Madison HTCondor Reconstruction Quickstart](docs/madison_condor_quickstart.md).**
+[Madison HTCondor End-to-End Quickstart](docs/madison_condor_quickstart.md).**
+It covers a clean checkout, shared conversion-runtime validation, Condor
+I3-to-SQLite conversion, SQLite checks, reconstruction-environment creation,
+all three GPU jobs, and output verification.
 
 Supporting references:
 
 - [Architecture and validation record](docs/unified_workflow.md)
 - [Condor operational reference](workflows/reconstruction/condor/README.md)
-- [I3-to-SQLite conversion boundary](workflows/conversion/README.md)
+- [I3-to-SQLite conversion reference](workflows/conversion/README.md)
 - [Model contracts and SHA256 checksums](models/MODELS.md)
 
-> Madison reconstruction uses a dedicated micromamba Python 3.8 / PyTorch 2.2
-> environment. Do not use the generic installation examples below, source the
-> IceCube CVMFS environment, or initialize micromamba in `.bashrc` for this
-> deployment.
+> Madison conversion and reconstruction use separate environments. Conversion
+> uses the validated shared IceTray/Python 3.12 runtime; reconstruction uses a
+> user-owned micromamba Python 3.8 / PyTorch 2.2 environment. Follow the
+> Quickstart instead of the generic installation examples below, and do not
+> initialize micromamba in `.bashrc`.
 
 ### Publications using GraphNeT
 

--- a/docs/madison_condor_quickstart.md
+++ b/docs/madison_condor_quickstart.md
@@ -95,6 +95,41 @@ git pull --ff-only
 The repository must be under shared storage such as `/data/user`; GPU workers
 cannot use a checkout located only under submitter-local `/scratch`.
 
+## Dependency and installation contract
+
+Cloning the repository supplies the GraphNeT source used by this workflow. Do
+not install the repository as a Python package into either Madison runtime. The
+conversion preflight and all reconstruction wrappers set `PYTHONPATH` to
+`$REPO/src`, so the checked-out custom classes and import paths are used
+directly.
+
+The authoritative dependency entry points are:
+
+| Scope | Authoritative files/runtime | Status |
+| --- | --- | --- |
+| Madison conversion | `environments/check_conversion_madison.sh` plus the complete shared IceTray/Python 3.12 overlay | Validated as one runtime |
+| Madison reconstruction | `environments/setup_reconstruction_madison.sh` and `environments/reconstruction-madison.yml` | Git-reproducible and validated |
+| Generic GraphNeT packaging | `setup.py`, `requirements/torch_*.txt`, and the generic Install section in `README.md` | Not a Madison deployment entry point |
+
+For the Madison workflow, do **not** run any of the following:
+
+```bash
+pip install .
+pip install -e .
+pip install -e '.[torch]'
+pip install -r requirements/torch_gpu.txt -e '.[develop,torch]'
+```
+
+Those generic package constraints are intentionally broader than the validated
+Condor contract. Resolving them again can replace the tested Torch/PyG pair,
+install a non-legacy-compatible Polars wheel, or change dependencies such as
+Awkward. A single `setup.py` also cannot describe both the IceTray/Python 3.12
+conversion runtime and the Python 3.8/CUDA reconstruction runtime.
+
+If you need a separate, general-purpose GraphNeT development installation,
+create a third environment and follow the generic installation documentation
+there. Never reuse or modify either validated Madison runtime for that purpose.
+
 ## Conversion phase: I3 + GCD -> SQLite
 
 The user-facing submission layer reuses the exact validated conversion baseline:

--- a/docs/madison_condor_quickstart.md
+++ b/docs/madison_condor_quickstart.md
@@ -1,22 +1,34 @@
-# Madison HTCondor Reconstruction Quickstart
+# Madison HTCondor End-to-End Quickstart
 
-This is the supported onboarding path for running the repository's Energy,
-Track/Cascade, and Direction/Vertex reconstruction workflows on the Madison
-HTCondor GPU pool.
+This is the supported onboarding path for the complete Madison workflow:
 
-The guide starts from one or more GraphNeT SQLite databases. If the input is
-still IceCube I3 + GCD, read [Conversion from I3](#conversion-from-i3) before
-continuing.
+```text
+IceCube I3 + matching GCD
+    -> GraphNeT SQLite
+    -> Energy reconstruction
+    -> Track/Cascade reconstruction
+    -> Direction/Vertex reconstruction
+```
 
-No Singularity image, container, IceTray setup, or shell activation is needed
-for SQLite reconstruction.
+The conversion and reconstruction stages deliberately use different
+environments. Conversion uses the complete shared Madison IceTray/Python 3.12
+runtime validated by this repository. Reconstruction uses a user-owned,
+Git-reproducible micromamba Python 3.8 / PyTorch 2.2 environment.
+
+A user who already has GraphNeT SQLite databases may skip the
+[conversion phase](#conversion-phase-i3--gcd---sqlite) and continue at
+[Install micromamba](#2-install-micromamba-without-modifying-bashrc).
+
+No Singularity image or container is required.
 
 ## What the workflow produces
 
-For each input database, the three independent jobs produce:
+Each manifest row produces one SQLite database. The three independent
+reconstruction jobs then produce:
 
-| Workflow | Model | Output suffix |
+| Stage | Model | Output |
 | --- | --- | --- |
+| I3/GCD conversion | none | one GraphNeT `.db` per I3 file |
 | Energy | `models/energy/energy_model.pth` | `_E.csv` |
 | Track/Cascade | `models/track_cascade/track_cascade_model.pth` | `TC.csv` |
 | Direction/Vertex | `models/direction_vertex/direction_vertex_model.pth` | `_DV.csv` |
@@ -47,17 +59,23 @@ You need:
 - a Madison account and access to `npx-submitter`;
 - writable `/data/user/$USER` and `/scratch/$USER` directories;
 - `git`, `curl`, and `tar` on the submit host;
-- one or more GraphNeT SQLite `.db` files directly inside one input directory;
-- the pulse table name used during conversion, commonly
-  `SplitRTCleanedInIcePulses` or `SRTInIcePulses`.
+- one or more IceCube I3 files and the matching GCD path for each file, or
+  existing GraphNeT SQLite databases;
+- the pulse series to extract, commonly `SplitRTCleanedInIcePulses` or
+  `SRTInIcePulses`.
 
-Start in a clean Bash shell. Do **not** source the IceCube CVMFS setup for
-reconstruction.
+GCD/I3 matching is dataset-specific. Complete that matching before submission
+and record it as the two-column manifest described below.
+
+Start in a clean Bash shell. Do not source IceCube CVMFS manually in the shell
+that will later configure reconstruction. The conversion preflight and Condor
+wrapper source CVMFS inside their own processes, while reconstruction wrappers
+clear IceCube environment variables before Python starts.
 
 ## 1. Clone `main` to shared storage
 
 ```bash
-export REPO="/data/user/$USER/software/graphnet"
+export REPO="/data/user/$USER/software/graphnet_unified"
 
 git clone --branch main --single-branch \
   https://github.com/JiyuanLiao2000/graphnet.git "$REPO"
@@ -76,6 +94,195 @@ git pull --ff-only
 
 The repository must be under shared storage such as `/data/user`; GPU workers
 cannot use a checkout located only under submitter-local `/scratch`.
+
+## Conversion phase: I3 + GCD -> SQLite
+
+The user-facing submission layer reuses the exact validated conversion baseline:
+
+- `workflows/conversion/exe.sh`
+- `workflows/conversion/conversion.py`
+
+Those files retain the working Madison IceTray and Python paths. The
+parameterized submit file under `workflows/conversion/condor/` supplies
+user-specific storage paths without changing the baseline.
+
+### A. Validate the complete shared conversion runtime
+
+Run the tracked preflight from the repository root:
+
+```bash
+cd "$REPO"
+bash environments/check_conversion_madison.sh
+```
+
+The default shared runtime is:
+
+```text
+IceCube CVMFS: /cvmfs/icecube.opensciencegrid.org/py3-v4.4.2/setup.sh
+IceTray:       /data/user/mlarson/icetray/build/env-shell.sh
+Python:        /data/user/jliao/envs/mlarson_graphnet_env/bin/python3
+site-packages: /data/user/jliao/envs/mlarson_graphnet_env/lib/python3.12/site-packages
+```
+
+Every path component was verified as readable/executable by ordinary Madison
+users. The Python executable resolves to the CVMFS Python 3.12.5 installation;
+the user path supplies the complete, validated site-packages overlay. Treat the
+overlay as one runtime rather than removing packages that may be implicit
+dependencies.
+
+A successful check ends with:
+
+```text
+Conversion runtime preflight: PASS
+converter: I3ToSQLiteConverter
+extractors: I3TruthExtractor I3FeatureExtractorIceCube86
+```
+
+The script supports `CVMFS_SETUP`, `ICETRAY_ENV_SHELL`,
+`CONVERSION_PYTHON`, and `CONVERSION_SITE_PACKAGES` overrides if the
+Madison shared deployment moves.
+
+### B. Prepare the conversion submit directory
+
+```bash
+export CONVERSION_SUBMIT_DIR="/scratch/$USER/graphnet-conversion"
+export CONVERSION_OUTPUT_DIR="/data/user/$USER/graphnet_workflow/sqlite"
+export PULSEMAP="SplitRTCleanedInIcePulses"
+
+mkdir -p "$CONVERSION_SUBMIT_DIR"
+
+cp "$REPO/workflows/conversion/exe.sh" \
+   "$REPO/workflows/conversion/conversion.py" \
+   "$REPO/workflows/conversion/condor/conversion.sub" \
+   "$CONVERSION_SUBMIT_DIR/"
+
+cd "$CONVERSION_SUBMIT_DIR"
+```
+
+The generic submit file invokes `/bin/bash exe.sh`, so the copied baseline
+script does not need an executable file mode. Logs stay in the submitter-local
+scratch directory. Final databases are written to shared
+`/data/user/$USER/graphnet_workflow/sqlite`.
+
+The defaults assume the checkout path used in section 1. For a different
+checkout, output directory, or pulse series, override the corresponding submit
+macros with `condor_submit -append`.
+
+### C. Create the GCD/I3 manifest
+
+Create `manifest.txt` with exactly two whitespace-separated paths per row:
+
+```text
+/shared/gcd/GCD_Run001.i3.gz /shared/i3/Run001.i3.zst
+/shared/gcd/GCD_Run002.i3.gz /shared/i3/Run002.i3.zst
+```
+
+The first column is the GCD; the second is the I3 file. GCD `.tar`,
+`.tar.gz`, and `.tgz` archives are supported. Paths containing whitespace
+are not supported by this manifest format.
+
+One manifest row queues one Condor process and produces one database named from
+the I3 basename.
+
+### D. Parse the job before submitting
+
+```bash
+condor_submit -dump conversion.ad conversion.sub
+
+grep -E '^(Cmd|Args|RequestCpus|RequestMemory|TransferInput|Out|Err|UserLog)' \
+  conversion.ad
+```
+
+Expected fields include:
+
+```text
+Cmd="/bin/bash"
+Args="exe.sh <GCD> <I3> <output> <pulsemap> <GraphNeT root>"
+RequestCpus=1
+RequestMemory=8192
+TransferInput="exe.sh,conversion.py"
+```
+
+`-dump` writes the resolved ClassAd locally and does not submit to the
+schedd. Its synthetic “submitted to cluster 1” message is not a live cluster.
+
+### E. Submit and monitor conversion
+
+```bash
+condor_submit \
+  -batch-name graphnet-conversion \
+  conversion.sub
+
+condor_q
+```
+
+The submit file requires workers with the IceCube CVMFS mount, transfers the
+two baseline scripts into the execute sandbox, and propagates conversion
+failures as nonzero job exit codes.
+
+After completion:
+
+```bash
+ls -lh conversion.*.log conversion.*.out conversion.*.err
+find "$CONVERSION_OUTPUT_DIR" -maxdepth 1 -type f -name '*.db' -print
+```
+
+The Condor event log must report normal termination with return value 0.
+
+### F. Validate the converted SQLite databases
+
+```bash
+export INPUT_DIR="$CONVERSION_OUTPUT_DIR"
+
+/usr/bin/python3 - "$INPUT_DIR" "$PULSEMAP" <<'PY'
+import glob
+import os
+import sqlite3
+import sys
+
+input_dir, pulsemap = sys.argv[1:]
+databases = sorted(glob.glob(os.path.join(input_dir, "*.db")))
+if not databases:
+    raise SystemExit(f"No .db files found in {input_dir}")
+
+for database in databases:
+    with sqlite3.connect(database) as connection:
+        tables = {
+            row[0]
+            for row in connection.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            )
+        }
+        missing = {"truth", pulsemap} - tables
+        if missing:
+            raise SystemExit(f"{database}: missing tables {sorted(missing)}")
+        truth_events = connection.execute(
+            "SELECT COUNT(DISTINCT event_no) FROM truth"
+        ).fetchone()[0]
+        pulse_events = connection.execute(
+            f"SELECT COUNT(DISTINCT event_no) FROM {pulsemap}"
+        ).fetchone()[0]
+        pulse_rows = connection.execute(
+            f"SELECT COUNT(*) FROM {pulsemap}"
+        ).fetchone()[0]
+
+    if truth_events != pulse_events:
+        raise SystemExit(
+            f"{database}: truth events={truth_events}, "
+            f"pulse events={pulse_events}"
+        )
+    print(
+        f"PASS: {database}: events={truth_events}, "
+        f"pulse rows={pulse_rows}"
+    )
+
+print("SQLite validation: PASS")
+PY
+```
+
+The validated end-to-end smoke produced 443 truth events, 443 pulse-table
+events, and 15,077 pulse rows. Continue only after the new databases pass this
+check.
 
 ## 2. Install micromamba without modifying `.bashrc`
 
@@ -187,12 +394,25 @@ preprocessing.
 
 ## 5. Check the SQLite input
 
-Set the input directory and pulse table:
+If you completed the conversion phase, `INPUT_DIR` already points to
+`$CONVERSION_OUTPUT_DIR` and `PULSEMAP` already records the extracted pulse
+series. Confirm them:
+
+```bash
+printf 'INPUT_DIR=%s\nPULSEMAP=%s\n' "$INPUT_DIR" "$PULSEMAP"
+```
+
+If you skipped conversion because databases already exist, set both variables
+now:
 
 ```bash
 export INPUT_DIR="/data/user/$USER/path/to/sqlite"
 export PULSEMAP="SplitRTCleanedInIcePulses"
+```
 
+Then discover the direct database children:
+
+```bash
 find "$INPUT_DIR" -maxdepth 1 -type f -name '*.db' -print
 ```
 
@@ -236,7 +456,7 @@ not repaired by the reconstruction job.
 
 ```bash
 export SUBMIT_DIR="/scratch/$USER/graphnet-reconstruction"
-export OUTPUT_BASE="/data/user/$USER/graphnet-reconstruction-output"
+export OUTPUT_BASE="/data/user/$USER/graphnet_workflow/reconstruction"
 
 mkdir -p "$SUBMIT_DIR" "$OUTPUT_BASE"
 cp "$REPO"/workflows/reconstruction/condor/{energy,track_cascade,direction_vertex}.{sh,sub} \
@@ -399,6 +619,8 @@ entry points.
 
 | Symptom | Cause | Action |
 | --- | --- | --- |
+| Conversion preflight reports an unreadable shared path | Madison shared runtime moved or permissions changed | Use the documented path override only after the replacement runtime is verified |
+| Conversion exits without a database | I3/GCD, pulse series, IceTray, or converter failure | Read the conversion `.err`, `.out`, and final Condor event-log entry |
 | `No module named encodings` | IceCube CVMFS set `PYTHONHOME`/`PYTHONPATH` | Start a clean shell and use the tracked reconstruction wrapper; do not source CVMFS |
 | `CXXABI_1.3.15 not found` | Worker loaded `/lib64/libstdc++.so.6` | Use the tracked wrapper and the environment created by the setup script |
 | `Failed to find a shell to run the script with` | Minimal worker `PATH` | Use the tracked wrapper, which adds `/usr/bin:/bin` before micromamba |
@@ -415,23 +637,32 @@ count and set `num_workers` to the same value.
 Do not work around the Polars failure with `POLARS_SKIP_CPU_CHECK`; skipping a
 check cannot add missing CPU instructions.
 
-## Conversion from I3
+## Environment boundary
 
-SQLite reconstruction and I3 conversion intentionally use different Python
-environments. The active conversion workflow is under `workflows/conversion/`,
-but its IceTray `env-shell`, private Python, and Python site-packages paths are
-Madison deployment-specific.
+Conversion and reconstruction intentionally remain separate:
 
-If starting from I3 + GCD, read `workflows/conversion/README.md`. Do not run
-IceCube CVMFS setup inside a reconstruction job, and do not try to load the
-serialized reconstruction models in the Python 3.12 conversion environment.
+| Stage | Runtime |
+| --- | --- |
+| I3/GCD -> SQLite | shared IceTray + CVMFS Python 3.12 runtime |
+| SQLite -> Energy/TC/DV | user-owned micromamba Python 3.8 + PyTorch 2.2/cu118 |
+
+Do not run IceCube CVMFS setup inside reconstruction jobs. Do not try to load
+the serialized reconstruction models in the Python 3.12 conversion runtime.
+The reconstruction wrappers clear `PYTHONHOME` and `PYTHONPATH` and select
+the environment C++ runtime before Python starts.
+
+See `workflows/conversion/README.md` for the conversion operational reference.
 
 ## Key files
 
 | Purpose | File |
 | --- | --- |
-| Environment installer | `environments/setup_reconstruction_madison.sh` |
-| Pinned dependency mirror | `environments/reconstruction-madison.yml` |
+| Shared conversion runtime preflight | `environments/check_conversion_madison.sh` |
+| Parameterized conversion submit file | `workflows/conversion/condor/conversion.sub` |
+| GCD/I3 manifest example | `workflows/conversion/condor/manifest.example` |
+| Validated conversion baseline | `workflows/conversion/exe.sh`, `conversion.py` |
+| Reconstruction environment installer | `environments/setup_reconstruction_madison.sh` |
+| Reconstruction dependency mirror | `environments/reconstruction-madison.yml` |
 | Condor operational reference | `workflows/reconstruction/condor/README.md` |
 | Energy entry point | `workflows/reconstruction/energy.py` |
 | Track/Cascade entry point | `workflows/reconstruction/track_cascade.py` |

--- a/docs/unified_workflow.md
+++ b/docs/unified_workflow.md
@@ -24,9 +24,10 @@ SQLite database
 PACE is the reconstruction regression environment. Madison/HTCondor is the
 deployment target for the complete workflow.
 
-New users should start with `docs/madison_condor_quickstart.md`. It provides the
-supported clone, environment creation, input validation, submission,
-monitoring, output verification, and troubleshooting path.
+New users should start with `docs/madison_condor_quickstart.md`. It provides
+the supported clean-checkout path from I3/GCD conversion through SQLite
+validation, reconstruction-environment creation, all three GPU jobs, output
+verification, and troubleshooting.
 
 ## GraphNeT baseline
 
@@ -61,13 +62,18 @@ The Madison elasticity behavior is also preserved.
 
 ## Conversion workflow
 
-The active conversion files are:
+The validated baseline files are:
 
 - `workflows/conversion/conversion.py`
 - `workflows/conversion/exe.sh`
 - `workflows/conversion/condor.sub`
 
-The original Madison files are preserved under
+They remain unchanged as the regression baseline. Ordinary users submit the
+same `exe.sh` and `conversion.py` through the parameterized layer:
+
+- `workflows/conversion/condor/conversion.sub`
+
+The original Madison reference files remain preserved under
 `workflows/conversion/reference/condor/`.
 
 Each Condor job follows this structure:
@@ -84,9 +90,9 @@ this single-file workflow does not require a merge operation.
 The pulse series is configurable and passes through the following files:
 
 ```text
-condor.sub
-    -> exe.sh
-    -> conversion.py
+workflows/conversion/condor/conversion.sub
+    -> baseline exe.sh
+    -> baseline conversion.py
 ```
 
 Example pulse series are `SplitRTCleanedInIcePulses` and
@@ -99,25 +105,27 @@ one `(GCD path, I3 path)` pair per Condor job.
 
 Conversion and reconstruction intentionally use separate environments.
 
-The conversion compatibility layer remains:
-
-- CVMFS IceCube setup
-- IceTray `env-shell`
-- private conversion Python environment
-- private Python site-packages and NumPy handling
-
-The reference conversion environment includes:
+The complete shared conversion runtime includes:
 
 - `/cvmfs/icecube.opensciencegrid.org/py3-v4.4.2/setup.sh`
 - `/data/user/mlarson/icetray/build/env-shell.sh`
 - `/data/user/jliao/envs/mlarson_graphnet_env/bin/python3`
+- `/data/user/jliao/envs/mlarson_graphnet_env/lib/python3.12/site-packages`
 
-The unified checkout is supplied through `PYTHONPATH` and must point to the
-current repository's `src` directory.
+The Python executable resolves to CVMFS Python 3.12.5. Permission checks
+confirmed that ordinary Madison users can read and execute every component.
+The full site-packages overlay remains intact so implicit conversion
+dependencies are not removed.
 
-The Madison conversion smoke test successfully produced
-`Greco_0414_Run00142433.db` from an I3 file and its GCD input. The resulting
-SQLite schema and event counts were validated.
+`environments/check_conversion_madison.sh` validates the shared runtime,
+current checkout, NumPy, IceCube, converter, and extractors without
+contaminating the caller's shell. The unified checkout is supplied through
+`PYTHONPATH` and points to the current repository's `src` directory.
+
+The original Madison conversion smoke and the later parameterized user-path
+smoke both produced `Greco_0414_Run00142433.db`. The later database contained
+443 matching truth/pulse events and 15,077 pulse rows before passing all three
+reconstruction workflows.
 
 ## Reconstruction workflows
 
@@ -350,40 +358,76 @@ checksums.
 All three unified reconstruction workflows passed PACE validation with the same
 SQLite database, `Greco_0610_Run00142709.db`.
 
-Madison validation currently stands at:
+Madison validation stands at:
 
 | Workflow / component | Status |
 | --- | --- |
-| I3 -> SQLite conversion | Passed |
-| Reconstruction micromamba environment | Passed |
-| Condor GPU allocation | Passed |
-| PyTorch CUDA computation | Passed |
-| Energy model load | Passed |
-| Track/cascade model load | Passed |
-| Direction/vertex model load | Passed |
-| Energy reconstruction on converted Madison DB | Passed |
-| Track/cascade reconstruction in a non-interactive Condor job | Passed |
-| Direction/vertex reconstruction in a non-interactive Condor job | Passed |
-| Energy reconstruction in a non-interactive Condor job | Passed |
-| Clean reconstruction environment recreation from Git definition | Passed |
-| All three model loads in the clean reconstruction environment | Passed |
-| Clean-environment Energy inference on a legacy CPU Condor worker | Passed |
+| Shared conversion runtime access and import preflight | Passed |
+| Parameterized user-facing conversion submit layer | Passed |
+| I3 + GCD -> SQLite in a non-interactive Condor job | Passed |
+| Converted SQLite truth/pulse event consistency | Passed |
+| Reconstruction micromamba environment recreation from Git | Passed |
+| Condor GPU allocation and CUDA computation | Passed |
+| Energy, Track/Cascade, and Direction/Vertex model loads | Passed |
+| Energy reconstruction in a non-interactive Condor GPU job | Passed |
+| Track/Cascade reconstruction in a non-interactive Condor GPU job | Passed |
+| Direction/Vertex reconstruction in a non-interactive Condor GPU job | Passed |
+| Clean-environment Energy inference on a legacy CPU worker | Passed |
+
+## End-to-end user-path validation
+
+The user-facing workflow was repeated from the repository branch on Madison on
+2026-08-14/15 using the parameterized conversion submit layer and the clean
+reconstruction environment.
+
+Conversion cluster `29550249` processed:
+
+```text
+GCD:
+  /data/exp/IceCube/2026/internal-system/sps-gcd/0414/
+  PFGCD_Run00142433_Subrun00000000.flat.tar
+
+I3:
+  /data/user/mlarson/icetray/scripts/upgrade_lid/output/
+  Greco_0414_Run00142433.i3.zst
+```
+
+The resulting database passed:
+
+```text
+truth:                     443 rows, 443 events
+SplitRTCleanedInIcePulses: 15077 rows, 443 events
+```
+
+That newly generated database was then used directly by three concurrent
+non-interactive GPU jobs:
+
+| Workflow | Cluster | Result |
+| --- | ---: | --- |
+| Energy | `29550452` | Passed |
+| Track/Cascade | `29550453` | Passed |
+| Direction/Vertex | `29550456` | Passed |
+
+All three produced the expected CSV files without changing the baseline
+conversion scripts or the reconstruction entry points.
 
 ## Completion status
 
-The complete Madison/HTCondor data path has passed:
+The complete Madison/HTCondor user path has passed:
 
 ```text
-I3 -> SQLite -> Energy / TC / DV
+clean checkout
+    -> shared conversion runtime preflight
+    -> parameterized I3/GCD conversion
+    -> SQLite schema/event validation
+    -> Git-recreated reconstruction environment
+    -> Energy / TC / DV Condor GPU jobs
+    -> validated CSV outputs
 ```
 
-Energy, Track/Cascade, and Direction/Vertex each produced validated CSV output
-from the converted Madison database in non-interactive Condor GPU jobs. The
-Git-managed reconstruction environment was recreated independently, all three
-serialized models loaded successfully, and Energy inference passed on a legacy
-CPU worker with the compatibility Polars build.
+The two-environment boundary remains intentional. Conversion uses the complete
+shared Madison IceTray/Python 3.12 runtime. Reconstruction uses the user-owned,
+Git-managed micromamba Python 3.8 / PyTorch 2.2 + CUDA 11.8 environment.
 
-The Madison deployment and reproducibility gates are complete. The verified
-integration was merged into `main` with its linear commit history preserved.
 Operational onboarding is maintained in
 `docs/madison_condor_quickstart.md`.

--- a/environments/check_conversion_madison.sh
+++ b/environments/check_conversion_madison.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Validate the complete shared Madison conversion runtime without modifying the
+# caller's shell. The defaults are the paths used by the validated I3-to-SQLite
+# workflow; each path can be overridden explicitly when the site deployment
+# changes.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GRAPHNET_ROOT="${GRAPHNET_ROOT:-$(cd "${SCRIPT_DIR}/.." && pwd)}"
+CVMFS_SETUP="${CVMFS_SETUP:-/cvmfs/icecube.opensciencegrid.org/py3-v4.4.2/setup.sh}"
+ICETRAY_ENV_SHELL="${ICETRAY_ENV_SHELL:-/data/user/mlarson/icetray/build/env-shell.sh}"
+CONVERSION_PYTHON="${CONVERSION_PYTHON:-/data/user/jliao/envs/mlarson_graphnet_env/bin/python3}"
+CONVERSION_SITE_PACKAGES="${CONVERSION_SITE_PACKAGES:-/data/user/jliao/envs/mlarson_graphnet_env/lib/python3.12/site-packages}"
+
+require_file() {
+    local path="$1"
+    local description="$2"
+    if [ ! -r "$path" ]; then
+        printf 'Missing or unreadable %s: %s\n' "$description" "$path" >&2
+        exit 1
+    fi
+}
+
+require_executable() {
+    local path="$1"
+    local description="$2"
+    if [ ! -x "$path" ]; then
+        printf 'Missing or non-executable %s: %s\n' "$description" "$path" >&2
+        exit 1
+    fi
+}
+
+require_executable "$CVMFS_SETUP" "IceCube CVMFS setup"
+require_executable "$ICETRAY_ENV_SHELL" "IceTray env-shell"
+require_executable "$CONVERSION_PYTHON" "conversion Python"
+require_file "$CONVERSION_SITE_PACKAGES" "conversion site-packages directory"
+require_file "$GRAPHNET_ROOT/src/graphnet/__init__.py" "GraphNeT checkout"
+
+# setup.sh emits shell code. This script is its own process, so the exported
+# IceCube variables do not contaminate the user's interactive shell.
+eval "$("$CVMFS_SETUP")"
+export PYTHONPATH="$GRAPHNET_ROOT/src:${PYTHONPATH:-}"
+
+"$ICETRAY_ENV_SHELL" "$CONVERSION_PYTHON" -     "$CONVERSION_SITE_PACKAGES" <<'PY'
+import sys
+
+site_packages = sys.argv[1]
+if site_packages in sys.path:
+    sys.path.remove(site_packages)
+sys.path.insert(0, site_packages)
+
+if "numpy" in sys.modules:
+    del sys.modules["numpy"]
+
+import graphnet
+import icecube
+import numpy
+from graphnet.data import I3ToSQLiteConverter
+from graphnet.data.extractors.icecube import (
+    I3FeatureExtractorIceCube86,
+    I3TruthExtractor,
+)
+
+print("Conversion runtime preflight: PASS")
+print("python:", sys.version)
+print("python executable:", sys.executable)
+print("numpy:", numpy.__version__)
+print("numpy location:", numpy.__file__)
+print("graphnet location:", graphnet.__file__)
+print("icecube location:", getattr(icecube, "__file__", None))
+print("converter:", I3ToSQLiteConverter.__name__)
+print("extractors:", I3TruthExtractor.__name__, I3FeatureExtractorIceCube86.__name__)
+PY
+
+printf 'GraphNeT root: %s\n' "$GRAPHNET_ROOT"
+printf 'IceTray env-shell: %s\n' "$ICETRAY_ENV_SHELL"
+printf 'Conversion Python: %s\n' "$CONVERSION_PYTHON"

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,13 @@
 # type: ignore[no-untyped-call]
 """Setup script for the GraphNeT package."""
 
+# Madison/HTCondor deployment note:
+# This file retains the generic GraphNeT package metadata. It is not the
+# dependency installer or lock file for the validated Madison workflow. That
+# workflow imports this checkout through PYTHONPATH and uses the two runtimes
+# documented in docs/madison_condor_quickstart.md. Do not use pip install .
+# or pip install -e .[torch] to prepare either Madison runtime.
+
 from setuptools import setup, find_packages
 import versioneer
 

--- a/workflows/conversion/README.md
+++ b/workflows/conversion/README.md
@@ -1,110 +1,247 @@
 # Madison HTCondor I3-to-SQLite conversion
 
-This directory contains the active Madison conversion workflow:
+This directory contains the validated Madison conversion stage for the complete
+workflow:
+
+```text
+IceCube I3 + matching GCD
+    -> GraphNeT SQLite
+    -> Energy / Track-Cascade / Direction-Vertex
+```
+
+New users should follow the complete
+`docs/madison_condor_quickstart.md`. This README is the operational reference
+for the conversion files.
+
+## Validated baseline and user-facing layer
+
+The three files directly under `workflows/conversion/` are the successful
+Madison baseline:
 
 - `conversion.py`
 - `exe.sh`
 - `condor.sub`
 
-Each Condor process converts one I3 file plus its matching GCD into one
-GraphNeT SQLite database. The pulse table name is a parameter.
+The baseline contains the original site and deployment paths and remains
+unchanged as a regression reference.
 
-## Important portability boundary
+Ordinary users submit through:
 
-The current conversion workflow is validated on Madison, but it is not a
-generic installation recipe. It intentionally depends on a site-specific
-IceCube Python 3.12 stack:
+- `workflows/conversion/condor/conversion.sub`
+- `workflows/conversion/condor/manifest.example`
 
-- IceCube CVMFS `py3-v4.4.2` setup;
-- an IceTray `env-shell` path;
-- a private Python executable;
-- a private Python `site-packages` path used by `conversion.py`.
+The parameterized submit file reuses the exact baseline `exe.sh` and
+`conversion.py`. It replaces user-specific repository, output, log, and
+manifest handling without reimplementing the converter.
 
-Those private paths are not committed as software artifacts and may not be
-readable by another user. A new user must obtain or build an equivalent
-IceTray/GraphNeT conversion environment and update the active workflow paths
-before submitting. The micromamba Python 3.8 reconstruction environment is not
-a replacement for this conversion environment.
+Files under `workflows/conversion/reference/condor/` preserve the earlier
+reference workflow and must not be modified.
 
-If SQLite databases already exist, skip this directory and follow
-`docs/madison_condor_quickstart.md`.
+## Shared Madison conversion runtime
 
-## Inputs
+Conversion uses this complete validated runtime:
 
-The conversion CLI is:
+```text
+IceCube CVMFS setup:
+  /cvmfs/icecube.opensciencegrid.org/py3-v4.4.2/setup.sh
+
+IceTray env-shell:
+  /data/user/mlarson/icetray/build/env-shell.sh
+
+Python:
+  /data/user/jliao/envs/mlarson_graphnet_env/bin/python3
+
+Python site-packages:
+  /data/user/jliao/envs/mlarson_graphnet_env/lib/python3.12/site-packages
+```
+
+The Python executable resolves to CVMFS Python 3.12.5. The user-owned path
+provides the full working site-packages overlay. Permission checks confirmed
+that ordinary Madison users can traverse, read, and execute every component.
+
+Treat the overlay as one validated runtime. Do not remove packages merely
+because they appear unrelated; imports may have implicit dependencies. This
+shared runtime is the default compatibility backend, so new users do not need
+to compile IceTray or reconstruct the conversion environment before their
+first job.
+
+If the shared deployment moves, the environment preflight supports explicit
+path overrides. The baseline files themselves should remain unchanged until a
+replacement runtime has passed the same end-to-end regression.
+
+## Preflight
+
+From the repository root:
+
+```bash
+bash environments/check_conversion_madison.sh
+```
+
+The script checks:
+
+- the CVMFS setup;
+- the shared IceTray `env-shell`;
+- the complete Python 3.12 overlay;
+- the current repository's GraphNeT source;
+- NumPy;
+- `I3ToSQLiteConverter`;
+- `I3TruthExtractor`;
+- `I3FeatureExtractorIceCube86`.
+
+A successful result contains:
+
+```text
+Conversion runtime preflight: PASS
+```
+
+The script runs CVMFS setup inside its own process and does not contaminate the
+caller's shell.
+
+Optional overrides are:
+
+```text
+CVMFS_SETUP
+ICETRAY_ENV_SHELL
+CONVERSION_PYTHON
+CONVERSION_SITE_PACKAGES
+GRAPHNET_ROOT
+```
+
+## Inputs and manifest
+
+The conversion CLI implemented by the baseline is:
 
 ```text
 conversion.py <gcd_file_path> <i3_file_path> <output_directory> <pulse_key>
 ```
 
-GCD/I3 matching is deliberately outside the converter. Generate a two-column,
-whitespace-separated manifest with one job per row:
+GCD/I3 matching is dataset-specific and deliberately remains outside the core
+converter. Copy `workflows/conversion/condor/manifest.example` as a starting
+point or create a two-column, whitespace-separated manifest:
 
 ```text
 /shared/path/GCD_Run001.i3.gz /shared/path/Run001.i3.zst
 /shared/path/GCD_Run002.i3.gz /shared/path/Run002.i3.zst
 ```
 
-GCD tar archives are supported by `exe.sh`; it extracts the first matching
-`*.i3*` file into a job-local temporary directory.
+The first column is the matching GCD; the second is the I3 file. Paths
+containing whitespace are not supported. One row queues one Condor process.
+
+GCD `.tar`, `.tar.gz`, and `.tgz` archives are supported. `exe.sh`
+extracts the first matching `*.i3*` member into a job-local temporary
+directory.
 
 Common pulse keys include:
 
 - `SplitRTCleanedInIcePulses`
 - `SRTInIcePulses`
 
-Use the pulse key actually present in the source I3 files. Reconstruction must
-later use the same table name.
+Reconstruction must use the same pulse table written during conversion.
 
-## Paths that must be reviewed
+## Prepare a submission
 
-Before submission, review all of the following:
+The standard checkout and output layout is:
 
-### `condor.sub`
+```text
+/data/user/$USER/software/graphnet_unified
+/data/user/$USER/graphnet_workflow/sqlite
+/scratch/$USER/graphnet-conversion
+```
 
-- `pulse_key`
-- `graphnet_root`
-- shared SQLite output directory in `arguments`
-- `/scratch/$USER/...` log, stdout, and stderr paths
-- manifest filename in the `queue ... from ...` line
+Prepare the submit directory:
 
-### `exe.sh`
+```bash
+export REPO="/data/user/$USER/software/graphnet_unified"
+export CONVERSION_SUBMIT_DIR="/scratch/$USER/graphnet-conversion"
 
-- IceCube CVMFS setup version
-- IceTray `env-shell.sh` path
-- private Python executable path
+mkdir -p "$CONVERSION_SUBMIT_DIR"
 
-### `conversion.py`
+cp "$REPO/workflows/conversion/exe.sh" \
+   "$REPO/workflows/conversion/conversion.py" \
+   "$REPO/workflows/conversion/condor/conversion.sub" \
+   "$CONVERSION_SUBMIT_DIR/"
 
-- private Python `site-packages` path (`my_env_path`)
+cd "$CONVERSION_SUBMIT_DIR"
+```
 
-Do not submit the tracked file unchanged under another account: its default
-paths are the validated author's smoke/deployment paths.
+Create `manifest.txt`, then parse the resolved ClassAd without submitting:
+
+```bash
+condor_submit -dump conversion.ad conversion.sub
+```
+
+The generic submit file uses:
+
+```text
+Cmd=/bin/bash
+Args=exe.sh <GCD> <I3> <output> <pulsemap> <GraphNeT root>
+RequestCpus=1
+RequestMemory=8 GB
+```
+
+It transfers both baseline scripts. Calling `/bin/bash exe.sh` avoids a
+dependency on the copied script's executable file mode.
+
+The custom manifest macro is called `input_manifest`; `manifest` is a
+reserved HTCondor boolean keyword and must not be reused.
+
+## Submit
+
+For the standard layout and default
+`SplitRTCleanedInIcePulses` pulse series:
+
+```bash
+condor_submit \
+  -batch-name graphnet-conversion \
+  conversion.sub
+```
+
+For a nonstandard checkout or output path, override the macros without editing
+the tracked template:
+
+```bash
+condor_submit conversion.sub \
+  -append "graphnet_root = /shared/path/graphnet" \
+  -append "output_dir = /shared/path/sqlite" \
+  -append "pulse_key = SRTInIcePulses" \
+  -append "input_manifest = another_manifest.txt"
+```
 
 ## Storage and Condor behavior
 
-- Submit and log files belong under submitter-local `/scratch/$USER/...`.
-- The repository, input I3/GCD, and final SQLite databases must be on storage
-  visible to execute workers, such as `/data/user/...` or experiment storage.
-- `should_transfer_files = YES` transfers `conversion.py` and captures job
-  output correctly.
-- Conversion failures propagate through `exe.sh` as a nonzero Condor exit
-  code.
+- Submit files and Condor logs belong under submitter-local
+  `/scratch/$USER/...`.
+- The repository, I3/GCD inputs, and final SQLite databases must be visible to
+  execute workers.
+- The generic default writes databases under
+  `/data/user/$USER/graphnet_workflow/sqlite`.
+- `should_transfer_files = YES` sends `exe.sh` and `conversion.py` to the
+  execute sandbox.
+- Conversion failures propagate as nonzero Condor exit codes.
+- One successful process produces one `.db` named from the I3 basename.
+- No database merge step is performed.
 
-One successful job produces one `.db` named from the I3 basename. No database
-merge step is performed by this workflow.
+## Validate before reconstruction
+
+Every new database must contain both `truth` and the selected pulse table.
+Their distinct `event_no` counts should agree.
+
+The end-to-end validation converted one test I3 file and produced:
+
+```text
+truth:                       443 events
+SplitRTCleanedInIcePulses:   443 events, 15077 rows
+```
+
+Use the complete SQLite validation command in
+`docs/madison_condor_quickstart.md` before launching reconstruction.
 
 ## Environment separation
 
-Do not source or reuse the conversion CVMFS environment for reconstruction.
+Do not reuse or source the conversion environment for reconstruction.
+Conversion uses IceTray and Python 3.12. Reconstruction uses the separate
+Git-managed micromamba Python 3.8 / PyTorch 2.2 + CUDA 11.8 environment.
+
 IceCube setup exports `PYTHONHOME` and `PYTHONPATH`, which can break the
-micromamba reconstruction Python. The reconstruction wrappers clear these
-variables and use the separate environment documented in
-`docs/madison_condor_quickstart.md`.
-
-## Active and reference files
-
-Use the files directly under `workflows/conversion/` for deployment. Files
-under `workflows/conversion/reference/condor/` preserve the original reference
-workflow and should not be modified.
-
+micromamba Python. The tracked reconstruction wrappers clear those variables
+and select the environment C++ runtime before starting Python.

--- a/workflows/conversion/condor/conversion.sub
+++ b/workflows/conversion/condor/conversion.sub
@@ -1,0 +1,37 @@
+# Parameterized Madison HTCondor submission layer for the validated conversion
+# baseline. Copy this file together with workflows/conversion/exe.sh and
+# workflows/conversion/conversion.py to a submit directory under /scratch/$USER.
+#
+# The defaults assume the repository layout documented in the end-to-end guide.
+# Override any macro with condor_submit -append when using a different layout.
+
+universe = vanilla
+executable = exe.sh
+
+submit_user = $ENV(USER)
+graphnet_root = /data/user/$(submit_user)/software/graphnet_unified
+output_dir = /data/user/$(submit_user)/graphnet_workflow/sqlite
+pulse_key = SplitRTCleanedInIcePulses
+manifest = manifest.txt
+
+arguments = "$(gcd_path)" "$(i3_path)" "$(output_dir)" "$(pulse_key)" "$(graphnet_root)"
+
+request_memory = 8GB
+request_cpus = 1
+
+transfer_executable = true
+should_transfer_files = YES
+when_to_transfer_output = ON_EXIT
+transfer_input_files = conversion.py
+
+output = conversion.$(ClusterId).$(ProcId).out
+error = conversion.$(ClusterId).$(ProcId).err
+log = conversion.$(ClusterId).log
+
+requirements = HAS_CVMFS_icecube_opensciencegrid_org && GLIDEIN_Site =!= "Cedar"
+max_retries = 0
++osg_site_blacklist = "Cedar"
+
+# The manifest contains two whitespace-separated columns:
+#   <GCD path> <I3 path>
+queue gcd_path, i3_path from $(manifest)

--- a/workflows/conversion/condor/conversion.sub
+++ b/workflows/conversion/condor/conversion.sub
@@ -12,7 +12,7 @@ submit_user = $ENV(USER)
 graphnet_root = /data/user/$(submit_user)/software/graphnet_unified
 output_dir = /data/user/$(submit_user)/graphnet_workflow/sqlite
 pulse_key = SplitRTCleanedInIcePulses
-manifest = manifest.txt
+input_manifest = manifest.txt
 
 arguments = exe.sh $(gcd_path) $(i3_path) $(output_dir) $(pulse_key) $(graphnet_root)
 
@@ -34,4 +34,4 @@ max_retries = 0
 
 # The manifest contains two whitespace-separated columns:
 #   <GCD path> <I3 path>
-queue gcd_path, i3_path from $(manifest)
+queue gcd_path, i3_path from $(input_manifest)

--- a/workflows/conversion/condor/conversion.sub
+++ b/workflows/conversion/condor/conversion.sub
@@ -14,7 +14,7 @@ output_dir = /data/user/$(submit_user)/graphnet_workflow/sqlite
 pulse_key = SplitRTCleanedInIcePulses
 manifest = manifest.txt
 
-arguments = "exe.sh" "$(gcd_path)" "$(i3_path)" "$(output_dir)" "$(pulse_key)" "$(graphnet_root)"
+arguments = exe.sh $(gcd_path) $(i3_path) $(output_dir) $(pulse_key) $(graphnet_root)
 
 request_memory = 8GB
 request_cpus = 1

--- a/workflows/conversion/condor/conversion.sub
+++ b/workflows/conversion/condor/conversion.sub
@@ -6,7 +6,7 @@
 # Override any macro with condor_submit -append when using a different layout.
 
 universe = vanilla
-executable = exe.sh
+executable = /bin/bash
 
 submit_user = $ENV(USER)
 graphnet_root = /data/user/$(submit_user)/software/graphnet_unified
@@ -14,15 +14,15 @@ output_dir = /data/user/$(submit_user)/graphnet_workflow/sqlite
 pulse_key = SplitRTCleanedInIcePulses
 manifest = manifest.txt
 
-arguments = "$(gcd_path)" "$(i3_path)" "$(output_dir)" "$(pulse_key)" "$(graphnet_root)"
+arguments = "exe.sh" "$(gcd_path)" "$(i3_path)" "$(output_dir)" "$(pulse_key)" "$(graphnet_root)"
 
 request_memory = 8GB
 request_cpus = 1
 
-transfer_executable = true
+transfer_executable = false
 should_transfer_files = YES
 when_to_transfer_output = ON_EXIT
-transfer_input_files = conversion.py
+transfer_input_files = exe.sh, conversion.py
 
 output = conversion.$(ClusterId).$(ProcId).out
 error = conversion.$(ClusterId).$(ProcId).err

--- a/workflows/conversion/condor/manifest.example
+++ b/workflows/conversion/condor/manifest.example
@@ -1,0 +1,2 @@
+/shared/path/GCD_Run001.i3.gz /shared/path/Run001.i3.zst
+/shared/path/GCD_Run002.i3.gz /shared/path/Run002.i3.zst


### PR DESCRIPTION
## Summary

This PR completes and documents the validated Madison HTCondor workflow:

```text
IceCube I3 + matching GCD
    -> GraphNeT SQLite
    -> Energy reconstruction
    -> Track/Cascade reconstruction
    -> Direction/Vertex reconstruction
```

It:

- adds a complete new-user Madison end-to-end Quickstart;
- adds a read-only preflight for the complete shared IceTray/Python 3.12 conversion runtime;
- adds a parameterized HTCondor conversion submit layer while preserving the validated baseline `exe.sh` and `conversion.py`;
- documents the two-environment architecture and shared/scratch/worker filesystem contract;
- records the tested reconstruction environment and Condor operational requirements;
- distinguishes the Madison dependency contract from generic `setup.py` / `pip install .` packaging paths.

## Validation

The documented path was executed end to end on Madison.

### Conversion

- conversion runtime preflight: **PASS**
- HTCondor conversion cluster: `29550249` — **PASS**
- output SQLite:
  `/data/user/jliao/graphnet_workflow/sqlite/Greco_0414_Run00142433.db`
- `truth`: 443 rows / 443 events
- `SplitRTCleanedInIcePulses`: 15077 rows / 443 events
- SQLite validation: **PASS**

### Reconstruction from the newly converted database

Using the independently recreated `graphnet-reco-verify` environment:

- Energy cluster `29550452`: **PASS**
- Track/Cascade cluster `29550453`: **PASS**
- Direction/Vertex cluster `29550456`: **PASS**
- all expected CSV outputs were produced and checked.

### Regression/scope checks

- existing conversion baseline scripts remain unchanged;
- reference scripts remain unchanged;
- reconstruction Python entry points, wrappers, and submit files remain unchanged;
- repository-local model files and detector preprocessing contracts remain unchanged;
- branch is based directly on current `main` with no divergence.

## Deployment notes

- Conversion intentionally uses the validated shared IceTray/Python 3.12 runtime.
- Reconstruction intentionally uses a separate micromamba Python 3.8 / PyTorch 2.2 + CUDA 11.8 runtime.
- No Singularity/container deployment is introduced.
- Condor logs remain under `/scratch/$USER`; final databases and CSV files remain under shared `/data/user/$USER`.
- Generic `setup.py` installation is not used for either validated Madison runtime.
